### PR TITLE
Crossbrowsing fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "next-ga": "^2.3.4",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "styled-components": "4.4.1"
+    "styled-components": "4.4.1",
+    "bowser": "2.7.0"
   },
   "devDependencies": {
     "@webcomponents/webcomponentsjs": "^2.4.0",

--- a/src/components/Calendar/Event.jsx
+++ b/src/components/Calendar/Event.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { BREAKPOINTS, COLORS } from '../../style/constants';
 import { SROnlyText } from '../SROnlyText';
 import { formatNumber } from '../../utils/format';
+import { browser } from '../../utils/browser';
 
 const Container = styled.a`
   display: flex;
@@ -13,6 +14,11 @@ const Container = styled.a`
   color: var(--color-primary-light);
   @media (min-width: ${BREAKPOINTS.lilac.mobile}) {
     margin-top: 0;
+    max-width: 100%;
+    ${({ inline }) => inline && css`
+      display: inline-block;
+      margin-bottom: -4px;
+    `}
   }
 `;
 
@@ -49,6 +55,7 @@ const EventInfo = styled.span`
   @media (min-width: ${BREAKPOINTS.lilac.mobile}) {
     border: 0;
     padding: 0;
+    display: block;
   }
 `;
 
@@ -66,6 +73,7 @@ const EventName = styled.span`
     font-weight: 400;
     font-size: inherit;
     color: inherit;
+    display: block;
   }
 `;
 
@@ -125,6 +133,7 @@ export const Event = ({
       href={link}
       target="_blank"
       aria-label="Abrir página del evento"
+      inline={browser.isEdgeHTML}
     >
       <EventDate>
         <span>

--- a/src/components/Calendar/Event.jsx
+++ b/src/components/Calendar/Event.jsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 import { BREAKPOINTS, COLORS } from '../../style/constants';
 import { SROnlyText } from '../SROnlyText';
 import { formatNumber } from '../../utils/format';
-import { browser } from '../../utils/browser';
+import { useEdgeHTML } from '../../hooks/useEdgeHTML';
 
 const Container = styled.a`
   display: flex;
@@ -128,12 +128,13 @@ export const Event = ({
   link,
 }) => {
   const fdate = new Date(date);
+  const edge = useEdgeHTML();
   return (
     <Container
       href={link}
       target="_blank"
       aria-label="Abrir página del evento"
-      inline={browser.isEdgeHTML}
+      inline={edge}
     >
       <EventDate>
         <span>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -141,6 +141,7 @@ const NavContainer = styled.nav`
   background-size: cover;
 
   &:target {
+    display: block;
     flex-direction: column;
     justify-content: flex-start;
     align-items: flex-start;

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,9 +1,10 @@
 import Link from 'next/link';
 import { withRouter } from 'next/router';
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { MENU } from '../data/constants';
 import { BREAKPOINTS } from '../style/constants';
+import { enableScroll, disableScroll } from '../utils/scroll';
 
 const LogoMobile = styled.img`
   display: block;
@@ -184,8 +185,13 @@ const NavContainer = styled.nav`
   }
 `;
 
-export const Nav = withRouter(
-  ({ router }) => (
+export const Nav = withRouter(({ router }) => {
+  useEffect(() => {
+    if (router.asPath.match(/#menu$/i)) {
+      disableScroll();
+    }
+  }, []);
+  return (
     <NavContainer id="menu">
       <Link href="/">
         <a href="/" title="Inicio">
@@ -205,18 +211,18 @@ export const Nav = withRouter(
           </MenuItem>
         ))}
       </Menu>
-      <MenuOpenButton href="#menu" title="Abrir menu">
+      <MenuOpenButton href="#menu" title="Abrir menu" onClick={disableScroll}>
         <img
           src="/icons/hamburger-menu.svg"
           alt="Abrir menu"
         />
       </MenuOpenButton>
-      <MenuCloseButton href="#" title="Cerrar menu">
+      <MenuCloseButton href="#" title="Cerrar menu" onClick={enableScroll}>
         <img
           src="/icons/chevron-up.svg"
           alt="Cerrar menu"
         />
       </MenuCloseButton>
     </NavContainer>
-  ),
-);
+  );
+});

--- a/src/hooks/useEdgeHTML.js
+++ b/src/hooks/useEdgeHTML.js
@@ -1,0 +1,11 @@
+import { useState, useEffect } from 'react';
+import { browser } from '../utils/browser';
+
+export const useEdgeHTML = () => {
+  const [isEdgeHTML, setIsEdgeHTML] = useState(false);
+  useEffect(() => {
+    setIsEdgeHTML(browser.isEdgeHTML);
+  }, []);
+
+  return isEdgeHTML;
+};

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -1,0 +1,18 @@
+/* global window */
+import Bowser from 'bowser';
+
+const browser = {
+  parser: null,
+  isEdgeHTML: false,
+};
+
+if (typeof window !== 'undefined') {
+  browser.parser = Bowser.getParser(window.navigator.userAgent);
+  browser.isEdgeHTML = browser.parser.satisfies({
+    windows: {
+      edge: '<19',
+    },
+  });
+}
+
+export { browser };

--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -1,0 +1,14 @@
+/* global window */
+const body = typeof window === 'undefined' ? null : window.document.body;
+
+export const enableScroll = () => {
+  body.style.position = '';
+  body.style.height = '';
+  body.style.overflow = '';
+};
+
+export const disableScroll = () => {
+  body.style.position = 'fixed';
+  body.style.height = '100%';
+  body.style.overflow = 'hidden';
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,6 +1443,11 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
+bowser@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.7.0.tgz#96eab1fa07fab08c1ec4c75977a7c8ddf8e0fe1f"
+  integrity sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
### What does this PR do?

It fixes a couple of bugs for when the site is used on browsers other than desktop Chrome & Firefox.

First, the calendar was showing the events with a weird alignment on MSEdge; I added a tool for browser detection and a custom hook to use on the components after they are rendered. 

The reason we are using a custom hook for a constant is that the solution for Edge breaks component for the rest of the browsers, so we had to use a class modifier.

When the site is served from SSR or as static HTML, the browser is never Edge, so the class modifier is not added; but on runtime, when React tries to hydrate the code, and the modifier is present, it throws an error saying that `className` doesn't match and ends up ignoring the modifier rules.

Moving on; the problem with the navigation menu on iOS was because, apparently, iOS doesn't render `nav` as a block; the change was backwards compatible with Blink.

And finally, the most awful fix: On mobile (on general), when the navigation menu was open, the scroll was still active on the background... and it was kind of weird.

I added a couple of functions to enable & disable the page scroll and `useEffect` to disable it if the page loaded when the menu open.

### How should it be tested manually?

1. Try the calendar on Edge 18.
2. Try the menu on iOS; the bug can be reproduced on the Simulator.
3. Try the menu on mobile and try to scroll when it's open.