### PR TITLE
Fix calendar current day issue

### DIFF
--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { BREAKPOINTS } from '../../style/constants';
@@ -55,6 +55,7 @@ const Subtitle = styled.h3``;
 
 export const Calendar = ({ name, events }) => {
   const today = new Date();
+  const [highlightCurrentDay, setHighlightCurrentDay] = useState(false);
   const [currentMonth, setCurrentMonth] = useState(today.getMonth());
   const [currentYear, setCurrentYear] = useState(today.getFullYear());
 
@@ -103,6 +104,8 @@ export const Calendar = ({ name, events }) => {
     }
   }, [currentMonth, currentYear, setCurrentMonth, setCurrentYear]);
 
+  useEffect(() => setHighlightCurrentDay(true), []);
+
   return (
     <Section>
       <Header>
@@ -124,7 +127,11 @@ export const Calendar = ({ name, events }) => {
           key={currentDay}
           day={currentDay}
           events={getEventsForDay(currentDay)}
-          isToday={currentMonth === today.getMonth() && currentDay === today.getDate()}
+          isToday={
+            highlightCurrentDay
+            && currentMonth === today.getMonth()
+            && currentDay === today.getDate()
+          }
         />
       ))}
       {hasNoEventsForMonth ? (

--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { BREAKPOINTS } from '../../style/constants';
@@ -53,35 +53,37 @@ const Title = styled.h2`
 
 const Subtitle = styled.h3``;
 
-export const Calendar = ({
-  name,
-  events,
-}) => {
+export const Calendar = ({ name, events }) => {
   const today = new Date();
   const [currentMonth, setCurrentMonth] = useState(today.getMonth());
   const [currentYear, setCurrentYear] = useState(today.getFullYear());
 
-  const getDaysInMonth = () => {
+  const daysInMonth = useMemo(() => {
     // passing 0 to the day parameter makes the new date to point to the last day of the previous
     // month; hence the currentMonth + 1
     const lastDay = new Date(currentYear, currentMonth + 1, 0);
-    return lastDay.getDate();
-  };
+    const numberOfDays = lastDay.getDate();
+    return Array.from(Array(numberOfDays), (_, index) => index + 1);
+  }, [currentYear, currentMonth]);
 
-  const hasEventsForMonth = () => events.find(({ date }) => {
-    const eventDate = new Date(date);
-    return eventDate.getFullYear() === currentYear
-      && eventDate.getMonth() === currentMonth;
-  }) != null;
+  const hasNoEventsForMonth = useMemo(() => (
+    events.find(({ date }) => {
+      const eventDate = new Date(date);
+      return eventDate.getFullYear() === currentYear
+        && eventDate.getMonth() === currentMonth;
+    }) == null
+  ), [events, currentYear, currentMonth]);
 
-  const getEventsForDay = (day) => events.filter(({ date }) => {
-    const eventDate = new Date(date);
-    return eventDate.getFullYear() === currentYear
-      && eventDate.getMonth() === currentMonth
-      && eventDate.getDate() === day;
-  });
+  const getEventsForDay = useCallback((day) => (
+    events.filter(({ date }) => {
+      const eventDate = new Date(date);
+      return eventDate.getFullYear() === currentYear
+        && eventDate.getMonth() === currentMonth
+        && eventDate.getDate() === day;
+    })
+  ), [currentMonth, currentYear, events]);
 
-  const handlePreviousMonthEvent = () => {
+  const handlePreviousMonthEvent = useCallback(() => {
     const nextCurrentMonth = currentMonth - 1;
     if (nextCurrentMonth < 0) {
       setCurrentMonth(11);
@@ -89,9 +91,9 @@ export const Calendar = ({
     } else {
       setCurrentMonth(nextCurrentMonth);
     }
-  };
+  }, [currentMonth, currentYear, setCurrentMonth, setCurrentYear]);
 
-  const handleNextMonthEvent = () => {
+  const handleNextMonthEvent = useCallback(() => {
     const nextCurrentMonth = currentMonth + 1;
     if (nextCurrentMonth > 11) {
       setCurrentMonth(0);
@@ -99,26 +101,8 @@ export const Calendar = ({
     } else {
       setCurrentMonth(nextCurrentMonth);
     }
-  };
+  }, [currentMonth, currentYear, setCurrentMonth, setCurrentYear]);
 
-  const renderDay = (currentDay) => (
-    <Day
-      key={currentDay}
-      day={currentDay}
-      events={getEventsForDay(currentDay)}
-      isToday={currentMonth === today.getMonth() && today.getDate() === currentDay}
-    />
-  );
-
-  const renderNoEventsOverlay = () => (
-    <lilac-overlay size="big" open>
-      <lilac-overlay-title>
-        No tenemos eventos agendados para este mes
-      </lilac-overlay-title>
-    </lilac-overlay>
-  );
-
-  const days = Array.from(Array(getDaysInMonth()), (_, index) => index + 1);
   return (
     <Section>
       <Header>
@@ -135,8 +119,21 @@ export const Calendar = ({
           </Subtitle>
         </SROnlyText>
       </Header>
-      {days.map(renderDay)}
-      {hasEventsForMonth() ? null : renderNoEventsOverlay()}
+      {daysInMonth.map((currentDay) => (
+        <Day
+          key={currentDay}
+          day={currentDay}
+          events={getEventsForDay(currentDay)}
+          isToday={currentMonth === today.getMonth() && currentDay === today.getDate()}
+        />
+      ))}
+      {hasNoEventsForMonth ? (
+        <lilac-overlay size="big" open>
+          <lilac-overlay-title>
+            No tenemos eventos agendados para este mes
+          </lilac-overlay-title>
+        </lilac-overlay>
+      ) : null}
     </Section>
   );
 };

--- a/src/components/Calendar/Day.jsx
+++ b/src/components/Calendar/Day.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { BREAKPOINTS } from '../../style/constants';
@@ -101,7 +101,7 @@ export const Day = ({
   events,
   isToday,
 }) => {
-  const isEmpty = events.length === 0;
+  const isEmpty = useMemo(() => events.length === 0, [events]);
   return (
     <Container
       aria-hidden={isEmpty}


### PR DESCRIPTION
# What does this PR do?
Fixes #16 by delaying the highlight of the current day until the component is mounted.
Also adds some optimizations to the component by using hooks to memoize callbacks and values.

# How should it be tested manually?
- Make sure the calendar components works the same as before after the optimizations
- Wait for a day or two too see if the bug is still there