### PR TITLE
Fix event hours due to timezone error

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -128,7 +128,7 @@
     "link": "https://www.eventbrite.com.ar/o/react-cba-29215693235"
   },
   {
-    "date": "2020-03-05T08:30:00.000Z",
+    "date": "2020-03-05T11:30:00.000Z",
     "name": "WIDS Córdoba",
     "street": "UTN Córdoba, Maestro M. Lopez esq. Cruz Roja",
     "city": "Córdoba",
@@ -160,7 +160,7 @@
     "link": "https://beerjscba.com"
   },
   {
-    "date": "2020-05-29T09:00:00.000Z",
+    "date": "2020-05-29T12:00:00.000Z",
     "name": "WebConf",
     "street": "UTN Córdoba, Maestro M. Lopez esq. Cruz Roja",
     "city": "Córdoba",
@@ -168,7 +168,7 @@
     "link": "https://webconf.tech"
   },
   {
-    "date": "2020-05-30T09:00:00.000Z",
+    "date": "2020-05-30T12:00:00.000Z",
     "name": "WebConf",
     "street": "UTN Córdoba, Maestro M. Lopez esq. Cruz Roja",
     "city": "Córdoba",
@@ -208,7 +208,7 @@
     "link": "https://beerjscba.com"
   },
   {
-    "date": "2020-10-09T09:00:00.000Z",
+    "date": "2020-10-09T12:00:00.000Z",
     "name": "NodeConf",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -216,7 +216,7 @@
     "link": "https://2020.nodeconfar.com/"
   },
   {
-    "date": "2020-10-10T09:00:00.000Z",
+    "date": "2020-10-10T12:00:00.000Z",
     "name": "NodeConf",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -232,7 +232,7 @@
     "link": "https://beerjscba.com"
   },
   {
-    "date": "2020-10-22T09:00:00.000Z",
+    "date": "2020-10-22T12:00:00.000Z",
     "name": "Nerdearla",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -240,7 +240,7 @@
     "link": "https://nerdear.la/"
   },
    {
-    "date": "2020-10-23T09:00:00.000Z",
+    "date": "2020-10-23T12:00:00.000Z",
     "name": "Nerdearla",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -248,7 +248,7 @@
     "link": "https://nerdear.la/"
   },
   {
-    "date": "2020-10-24T09:00:00.000Z",
+    "date": "2020-10-24T12:00:00.000Z",
     "name": "Nerdearla",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -272,7 +272,7 @@
     "link": "https://beerjscba.com"
   },
   {
-    "date": "2020-06-22T08:30:00.000Z",
+    "date": "2020-06-22T11:30:00.000Z",
     "name": "JCC-BD&ET",
     "street": "Universidad de La Plata",
     "city": "La Plata",
@@ -280,7 +280,7 @@
     "link": "https://jcc.info.unlp.edu.ar/"
   },
   {
-    "date": "2020-06-23T08:30:00.000Z",
+    "date": "2020-06-23T11:30:00.000Z",
     "name": "JCC-BD&ET",
     "street": "Universidad de La Plata",
     "city": "La Plata",
@@ -288,7 +288,7 @@
     "link": "https://jcc.info.unlp.edu.ar/"
   },
   {
-    "date": "2020-06-24T08:30:00.000Z",
+    "date": "2020-06-24T11:30:00.000Z",
     "name": "JCC-BD&ET",
     "street": "Universidad de La Plata",
     "city": "La Plata",
@@ -296,7 +296,7 @@
     "link": "https://jcc.info.unlp.edu.ar/"
   },
   {
-    "date": "2020-06-25T08:30:00.000Z",
+    "date": "2020-06-25T11:30:00.000Z",
     "name": "JCC-BD&ET",
     "street": "Universidad de La Plata",
     "city": "La Plata",
@@ -304,7 +304,7 @@
     "link": "https://jcc.info.unlp.edu.ar/"
   },
   {
-    "date": "2020-06-26T08:30:00.000Z",
+    "date": "2020-06-26T11:30:00.000Z",
     "name": "JCC-BD&ET",
     "street": "Universidad de La Plata",
     "city": "La Plata",
@@ -312,7 +312,7 @@
     "link": "https://jcc.info.unlp.edu.ar/"
   },
   {
-    "date": "2020-04-21T08:30:00.000Z",
+    "date": "2020-04-21T11:30:00.000Z",
     "name": "Segurinfo",
     "street": "Buenos Aires Sheraton Hotel & Convention Center",
     "city": "Buenos Aires",
@@ -320,7 +320,7 @@
     "link": "https://segurinfo.org/argentina-2020/"
   },
   {
-    "date": "2020-02-27T08:30:00.000Z",
+    "date": "2020-02-27T11:30:00.000Z",
     "name": "ICSPD",
     "street": "TBD",
     "city": "Buenos Aires",
@@ -328,7 +328,7 @@
     "link": "https://waset.org/software-programming-and-databases-conference-in-february-2020-in-buenos-aires"
   },
   {
-    "date": "2020-02-28T08:30:00.000Z",
+    "date": "2020-02-28T11:30:00.000Z",
     "name": "ICSPD",
     "street": "TBD",
     "city": "Buenos Aires",
@@ -336,7 +336,7 @@
     "link": "https://waset.org/software-programming-and-databases-conference-in-february-2020-in-buenos-aires"
   },
   {
-    "date": "2020-09-25T09:30:00.000Z",
+    "date": "2020-09-25T12:30:00.000Z",
     "name": "PyData Córdoba",
     "street": "TBD",
     "city": "Córdoba",
@@ -344,7 +344,7 @@
     "link": "https://twitter.com/PyDataCba"
   },
   {
-    "date": "2020-09-26T09:30:00.000Z",
+    "date": "2020-09-26T12:30:00.000Z",
     "name": "PyData Córdoba",
     "street": "TBD",
     "city": "Córdoba",
@@ -352,7 +352,7 @@
     "link": "https://twitter.com/PyDataCba"
   },
   {
-    "date": "2020-09-27T09:30:00.000Z",
+    "date": "2020-09-27T12:30:00.000Z",
     "name": "PyData Córdoba",
     "street": "TBD",
     "city": "Córdoba",
@@ -360,7 +360,7 @@
     "link": "https://twitter.com/PyDataCba"
   },
   {
-    "date": "2020-09-23T09:00:00.000Z",
+    "date": "2020-09-23T12:00:00.000Z",
     "name": "EKOPARTY 16",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -368,7 +368,7 @@
     "link": "https://ekoparty.org/event/ekoparty-16-2020-09-23-2020-09-26-5/register"
   },
   {
-    "date": "2020-09-24T09:00:00.000Z",
+    "date": "2020-09-24T12:00:00.000Z",
     "name": "EKOPARTY 16",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -376,7 +376,7 @@
     "link": "https://ekoparty.org/event/ekoparty-16-2020-09-23-2020-09-26-5/register"
   },
   {
-    "date": "2020-09-25T09:00:00.000Z",
+    "date": "2020-09-25T12:00:00.000Z",
     "name": "EKOPARTY 16",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -384,7 +384,7 @@
     "link": "https://ekoparty.org/event/ekoparty-16-2020-09-23-2020-09-26-5/register"
   },
   {
-    "date": "2020-09-26T09:00:00.000Z",
+    "date": "2020-09-26T12:00:00.000Z",
     "name": "EKOPARTY 16",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -392,7 +392,7 @@
     "link": "https://ekoparty.org/event/ekoparty-16-2020-09-23-2020-09-26-5/register"
   },
   {
-    "date": "2020-06-11T09:00:00.000Z",
+    "date": "2020-06-11T12:00:00.000Z",
     "name": "Buzzconf Workshops",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -400,7 +400,7 @@
     "link": "https://buzzconf.org/"
   },
   {
-    "date": "2020-06-12T09:00:00.000Z",
+    "date": "2020-06-12T12:00:00.000Z",
     "name": "Buzzconf",
     "street": "Ciudad Cultural Konex, Sarmiento 3131, CABA",
     "city": "Buenos Aires",
@@ -408,7 +408,7 @@
     "link": "https://buzzconf.org/"
   },
   {
-    "date": "2020-07-20T09:00:00.000Z",
+    "date": "2020-07-20T12:00:00.000Z",
     "name": "ECIDCUBA #34",
     "street": "Pabellon 1, Ciudad Universitaria, CABA",
     "city": "Buenos Aires",
@@ -416,7 +416,7 @@
     "link": "https://eci2020.dc.uba.ar/index.html"
   },
   {
-    "date": "2020-07-21T09:00:00.000Z",
+    "date": "2020-07-21T12:00:00.000Z",
     "name": "ECIDCUBA #34",
     "street": "Pabellon 1, Ciudad Universitaria, CABA",
     "city": "Buenos Aires",
@@ -424,7 +424,7 @@
     "link": "https://eci2020.dc.uba.ar/index.html"
   },
   {
-    "date": "2020-07-22T09:00:00.000Z",
+    "date": "2020-07-22T12:00:00.000Z",
     "name": "ECIDCUBA #34",
     "street": "Pabellon 1, Ciudad Universitaria, CABA",
     "city": "Buenos Aires",
@@ -432,7 +432,7 @@
     "link": "https://eci2020.dc.uba.ar/index.html"
   },
   {
-    "date": "2020-07-23T09:00:00.000Z",
+    "date": "2020-07-23T12:00:00.000Z",
     "name": "ECIDCUBA #34",
     "street": "Pabellon 1, Ciudad Universitaria, CABA",
     "city": "Buenos Aires",
@@ -440,7 +440,7 @@
     "link": "https://eci2020.dc.uba.ar/index.html"
   },
   {
-    "date": "2020-07-24T09:00:00.000Z",
+    "date": "2020-07-24T12:00:00.000Z",
     "name": "ECIDCUBA #34",
     "street": "Pabellon 1, Ciudad Universitaria, CABA",
     "city": "Buenos Aires",
@@ -448,7 +448,7 @@
     "link": "https://eci2020.dc.uba.ar/index.html"
   },
   {
-    "date": "2020-03-14T09:00:00.000Z",
+    "date": "2020-03-14T12:00:00.000Z",
     "name": "Testathon",
     "street": "TBD",
     "city": "Buenos Aires",
@@ -456,7 +456,7 @@
     "link": "https://testathon.co/more-info---buenos-aires-saturday-march-14th/"
   },
   {
-    "date": "2020-03-15T09:00:00.000Z",
+    "date": "2020-03-15T12:00:00.000Z",
     "name": "Testathon",
     "street": "TBD",
     "city": "Buenos Aires",
@@ -464,7 +464,7 @@
     "link": "https://testathon.co/more-info---buenos-aires-saturday-march-14th/"
   },
   {
-    "date": "2020-06-11T09:00:00.000Z",
+    "date": "2020-06-11T12:00:00.000Z",
     "name": "EKOPARTY CBA",
     "street": "TBD",
     "city": "Córdoba",
@@ -472,7 +472,7 @@
     "link": "https://www.eventbrite.com.ar/e/ekoparty-cordoba-2020-tickets-94013911139"
   },
   {
-    "date": "2020-03-03T18:30:00.000Z",
+    "date": "2020-03-03T21:30:00.000Z",
     "name": "Android Hacking",
     "street": "Córdoba Hacker Space, Edificio Miragolf, Av. La Voz del Interior 7000",
     "city": "Córdoba",


### PR DESCRIPTION
I inadvertedly added a bunch of events with the hour referencing UTC-3, instead of using UTC+0. This PR corrects it.