### PR TITLE
Adds support for official comuniqués

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ module.exports = withCSS(withFonts({
         { source: '/', destination: '/' },
         { source: '/conocenos', destination: '/about' },
         { source: '/codigo-de-conducta', destination: '/coc' },
+        { source: '/comunicaciones', destination: '/comuniques' },
       ];
     },
     catchAllRouting: true,

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -57,7 +57,8 @@ const SocialMediaContainer = styled.div`
 export const Footer = () => (
   <FooterContainer>
     <FooterContent>
-      © 2019 | Comunidad de Desarrolladores de Argentina
+      {`© 2019 - ${new Date().getFullYear()} | `}
+      Comunidad de Desarrolladores de Argentina
       <SocialMediaContainer>
         <a href="https://www.instagram.com/somoscodear/" target="_blank" rel="noopener noreferrer">
           <img src="/images/social-media-logos/logo-instagram.svg" alt="instagram" />

--- a/src/comuniques.json
+++ b/src/comuniques.json
@@ -1,0 +1,40 @@
+[
+  {
+    "slug": "covid-19",
+    "title": "Comunicado oficial por COVID-19",
+    "date": "12 de Marzo de 2020",
+    "content": [
+      "Desde la Comisión Directiva de la Comunidad de Desarrolladores de Argentina, estamos siguiendo día a día las novedades sobre la emergencia sanitaria declarada por la Presidencia de la Nación y las medidas preventivas tomadas por los gobiernos de la Provincia de Córdoba y de la Municipalidad de Córdoba, a raíz de la situación de pandemia del coronavirus COVID-19.",
+
+      "En esta comunicación, queremos informar sobre las medidas que estamos tomando respecto al desarrollo de nuestras actividades.",
+
+      {
+        "type": "subtitle",
+        "content": "Sobre WebConf 2020"
+      },
+
+      "Estando a poco menos de tres meses de la fecha de WebConf 2020 y sin información concreta sobre cuándo finalizarán las medidas preventivas locales, consideramos que aún es muy pronto para decidir sobre suspender, posponer o cancelar el evento de este año. Por el momento, seguiremos trabajando con las personas que han postulado sus propuestas de charla y con las organizaciones que se han acercado para participar en calidad de auspiciantes. Estamos siguiendo las resoluciones emitidas conjuntamente por el Ministerio de Educación y el Ministerio de Salud que afectan al funcionamiento de la Universidad Tecnológica de Córdoba, que sería la sede de WebConf 2020, así como también manteniendo contacto con la Universidad respecto a cualquier decisión que tome en esta situación.",
+
+      {
+        "type": "subtitle",
+        "content": "Sobre el funcionamiento de la Asociación"
+      },
+
+      "La Comisión Directiva opera mayormente a través de plataformas on-line, con lo cual no habrá muchos cambios respecto a cómo trabajamos en el día a día. Sin embargo, hemos decidido preventivamente reemplazar nuestras reuniones presenciales por reuniones on-line.",
+
+      {
+        "type": "subtitle",
+        "content": "Sobre CoDeAr y las comunidades"
+      },
+
+      "A partir del 16 de marzo, vamos a abrir nuestra plataforma de servicios digitales para todas aquellas comunidades que deseen realizar eventos on-line. Estamos preparados para ofrecer cuentas con Google Meet (para realizar llamadas con hasta 100 personas), Google Classroom (para el seguimiento de cursos on-line) y Google Drive (para almacenar archivos), bajo una cuenta de correo @comunidades.codear.org. Publicaremos un formulario de inscripción para aquellas comunidades que deseen hacer uso de estos servicios sin cargo alguno.",
+
+      "Continuaremos publicando actualizaciones a medida que la situación evolucione.",
+
+      {
+        "type": "emphasis",
+        "content": "Recomendamos a todas las personas tomar las medidas de prevención y seguridad para cuidar su salud y contribuir a una salida positiva de esta emergencia sanitaria."
+      }
+    ]
+  }
+]

--- a/src/data/constants/menu.js
+++ b/src/data/constants/menu.js
@@ -9,4 +9,8 @@ export const MENU = [
     ...ROUTES.COC,
     label: 'Código de conducta',
   },
+  {
+    ...ROUTES.COMUNIQUES,
+    label: 'Comunicaciones',
+  },
 ];

--- a/src/data/constants/routes.js
+++ b/src/data/constants/routes.js
@@ -19,4 +19,8 @@ export const ROUTES = {
     path: '/codigo-de-conducta',
     page: '/coc',
   },
+  COMUNIQUES: {
+    path: '/comunicaciones',
+    page: '/comuniques',
+  },
 };

--- a/src/pages/comuniques.jsx
+++ b/src/pages/comuniques.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import styled from 'styled-components';
+import { BREAKPOINTS } from '../style/constants';
+import comuniques from '../comuniques.json';
+
+const Content = styled.div`
+  margin: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  h1 {
+    font-size: 3rem;
+    line-height: 1.1;
+  }
+
+  h2 {
+    font-size: 1.875rem;
+    color: var(--color-accent);
+    margin-top: 0;
+    border-bottom: 1px solid var(--color-accent);
+    padding-bottom: 1rem;
+  }
+
+  h3 {
+    font-size: 1.5rem;
+    color: var(--color-primary-lightest);
+  }
+
+  p, li {
+    font-size: 1.25rem;
+    font-family: Source Sans Pro, sans-serif;
+    line-height: 1.5;
+    color: var(--color-primary);
+  }
+
+  @media (min-width: ${BREAKPOINTS.hd}) {
+    align-self: center;
+    max-width: 73.75rem;
+    width: 100%;
+
+    h1 {
+      font-size: 4.5rem;
+    }
+
+    h2 {
+      font-size: 3rem;
+    }
+
+    p {
+      margin-left: 0;
+    }
+  }
+`;
+
+const PlaceAndDate = styled.p`
+  font-style: italic;
+`;
+
+const Components = {
+  p: ({ children }) => <p>{children}</p>,
+  subtitle: ({ children }) => <h3>{children}</h3>,
+  indentedBlock: ({ children }) => <IndentedBlock>{children}</IndentedBlock>,
+  emphasis: ({ children }) => <p><strong>{children}</strong></p>,
+}
+
+const Comuniques = () => (
+  <Content>
+    <h1>
+      comunicaciones
+    </h1>
+    {comuniques.map((comunique, index) => <article key={`comunique${index}`}>
+      <a name={comunique.slug}></a>
+      <PlaceAndDate>Córdoba, {comunique.date}</PlaceAndDate>
+      <h2>{comunique.title}</h2>
+      {comunique.content.map(block => block.type ? Components[block.type]({ children: block.content }) : Components.p({ children: block }))}
+    </article>)}
+  </Content>
+);
+
+Comuniques.getInitialProps = async () => ({
+  title: 'Comunicaciones',
+});
+
+export default Comuniques;

--- a/src/pages/comuniques.jsx
+++ b/src/pages/comuniques.jsx
@@ -79,7 +79,15 @@ const Comuniques = () => (
 );
 
 Comuniques.getInitialProps = async () => ({
-  title: 'Comunicaciones',
+  title: `${comuniques[0].title} | Comunicaciones`,
+  meta: {
+    ogTitle: `${comuniques[0].title} | CoDeAr`,
+    ogDescription: comuniques[0].content[0],
+    description: comuniques[0].content[0],
+    ogUrl: `https://codear.org/comunicaciones#${comuniques[0].slug}`,
+    twitterTitle: `${comuniques[0].title} | CoDeAr`,
+    twitterDescription: comuniques[0].content[0],
+  },
 });
 
 export default Comuniques;


### PR DESCRIPTION
Adds a page to post official comuniqués from the association. The data source is a JSON file with the following structure:

```js
[
  {
    "slug": "my-post",
    "title": "An important message",
    "date": "March 12nd, 2020",
    "content": [
      // String content is rendered as paragraphs.
      "This is an important message.",

      // Objects are rendered as different components according to their type.
      {
        "type": "subtitle",
        "content": "Why?"
      },

      "Because I said so."
    ]
  }
]
```