### PR TITLE
Elimina el link de Twitter para No Lo Testeamos

### DIFF
--- a/src/communities.json
+++ b/src/communities.json
@@ -450,10 +450,6 @@
     "description": "El único podcast en donde te van a contar el lado B del mundo IT.",
     "links": [
       {
-        "type": "twitter",
-        "handler": "nolotesteamos"
-      },
-      {
         "type": "web",
         "handler": "https://anchor.fm/no-lo-testeamos"
       }


### PR DESCRIPTION
El link no funciona más.