### PR TITLE
Release 26-09-2020 (2)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
   "alias": ["codear.org"],
   "redirects": [
     {
+      "source": "/hacktoberfest",
+      "destination": "https://youtube.com/codear"
+    },
+    {
       "source": "/hacktoberfest/coc",
       "destination": "https://docs.google.com/document/d/1HTHDu1YwzYGNergvJ7WnDW6Db_uXy6gNXUouLNHhtF0/edit"
     },


### PR DESCRIPTION
Yes, this should've been part of #178 , but after I made the relase I realized that we needed to put a URL where the "event is going to take place" and we discussed during one of the mettings that we would do a temp redirection to the youtube channel for now and, after we schedule the actual event on Streamyard, replace the redirection.

Sorry for the double release.