### PR TITLE
fix(calendar): use the right color for links of the current day

### DIFF
--- a/src/components/Calendar/Day.jsx
+++ b/src/components/Calendar/Day.jsx
@@ -103,7 +103,7 @@ const dayContainerCalendar = css`
         color: var(--color-text);
         font-weight: 700;
       }
-      ${Events}, a {calendarViewMode
+      ${Events}, a {
         color: var(--color-text);
       }
       &:hover lilac-icon-bullet {


### PR DESCRIPTION
While working on #179 && #178 I noticed that the calendar events for the current day had the wrong text color.